### PR TITLE
streamline the state-machine code

### DIFF
--- a/app/src/state_machine.cpp
+++ b/app/src/state_machine.cpp
@@ -17,7 +17,7 @@
  *  11-Oct-2023: Steve Meisner (steve@meisners.net) - Add suport for home automation (MQTT & Matter)
  * 
  */
-
+#include <stdbool.h>
 #include "thermostat.hpp"
 #include "driver/gpio.h"
 #define HIGH 1
@@ -32,11 +32,76 @@ int64_t lastMqttReconnect = 0;
 static bool MqttConnectCalled = false;
 
 
+struct gpio_pin_desc {
+  short pin;
+  short level;
+};
+
+#define NR_GPIO_PINS      (8)
+#define INVALID_PIN()     {.pin=-1, .level=-1} /* plays as an arbitrary stop guard for the iterator code */
+#define PIN(p, l)         {.pin=(p), .level=(l)}
+#define DESC(mode, ...)   [(mode)] = {__VA_ARGS__, INVALID_PIN()}
+
+/*
+ * NOTE: g++ doesn't support C's non-trivial designated initializers,
+ * so the array must be initilazed in the HVAC_MODE enum order
+ */
+const struct gpio_pin_desc hvac_mode_gpio[NR_HVAC_MODES][NR_GPIO_PINS] = {
+  DESC(OFF, PIN(HVAC_HEAT_PIN, LOW), PIN(HVAC_COOL_PIN, LOW), PIN(HVAC_FAN_PIN, LOW),
+            PIN(LED_HEAT_PIN, LOW), PIN(LED_COOL_PIN, LOW), PIN(LED_FAN_PIN, LOW),
+            PIN(HVAC_STAGE2_PIN, LOW)),
+  DESC(HEAT, PIN(HVAC_HEAT_PIN, HIGH), PIN(HVAC_COOL_PIN, LOW), PIN(HVAC_FAN_PIN, LOW),
+             PIN(LED_HEAT_PIN, HIGH), PIN(LED_COOL_PIN, LOW), PIN(LED_FAN_PIN, LOW),
+             PIN(HVAC_STAGE2_PIN, LOW)),
+  DESC(COOL, PIN(HVAC_HEAT_PIN, LOW), PIN(HVAC_COOL_PIN, HIGH), PIN(HVAC_FAN_PIN, LOW),
+             PIN(LED_HEAT_PIN, LOW), PIN(LED_COOL_PIN, HIGH), PIN(LED_FAN_PIN, LOW),
+             PIN(HVAC_STAGE2_PIN, LOW)),
+  DESC(DRY, INVALID_PIN()),
+  DESC(IDLE, PIN(HVAC_HEAT_PIN, LOW), PIN(HVAC_COOL_PIN, LOW), PIN(HVAC_FAN_PIN, LOW),
+             PIN(LED_HEAT_PIN, LOW), PIN(LED_COOL_PIN, LOW), PIN(LED_FAN_PIN, LOW),
+             PIN(HVAC_STAGE2_PIN, LOW)),
+  DESC(FAN_ONLY, PIN(HVAC_HEAT_PIN, LOW), PIN(HVAC_COOL_PIN, LOW), PIN(HVAC_FAN_PIN, HIGH),
+                 PIN(LED_HEAT_PIN, LOW), PIN(LED_COOL_PIN, LOW), PIN(LED_FAN_PIN, HIGH),
+                 PIN(HVAC_STAGE2_PIN, LOW)),
+};
+
+static inline bool is_invalid_desc(const struct gpio_pin_desc desc)
+{
+  struct gpio_pin_desc inv = INVALID_PIN();
+
+  if (desc.pin == inv.pin && desc.level == inv.level)
+    return true;
+
+  return false;
+}
+
+static void set_hvac_mode(HVAC_MODE mode)
+{
+  const struct gpio_pin_desc *desc = hvac_mode_gpio[mode];
+
+  for (int i = 0; i < NR_GPIO_PINS; i++) {
+    if (is_invalid_desc(desc[i]))
+      break;
+
+    gpio_set_level((gpio_num_t)desc[i].pin, (uint32_t)desc[i].level);
+  }
+
+  OperatingParameters.hvacOpMode = mode;
+}
+
+#define COND_LOG(cond, log_msg, ...)              \
+do {                                              \
+  if ((cond)) {                                   \
+    ESP_LOGI(__FUNCTION__, log_msg, __VA_ARGS__); \
+  }                                               \
+} while(0)
+
 void hvacStateUpdate()
 {
   float currentTemp;
   float minTemp, maxTemp;
   float autoMinTemp, autoMaxTemp;
+  HVAC_MODE prev_mode = OperatingParameters.hvacOpMode;
 
   currentTemp = OperatingParameters.tempCurrent + OperatingParameters.tempCorrection;
   minTemp = OperatingParameters.tempSet - (OperatingParameters.tempSwing / 2.0);
@@ -51,184 +116,65 @@ void hvacStateUpdate()
     autoMaxTemp = maxTemp;
 #endif
 
-  if (OperatingParameters.hvacSetMode == OFF)
-  {
-    if (OperatingParameters.hvacOpMode != OFF)
-      ESP_LOGI(__FUNCTION__, "Entering off mode: Current: %.2f", currentTemp);
-
-    OperatingParameters.hvacOpMode = OFF;
-    gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-    gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-    gpio_set_level((gpio_num_t)HVAC_FAN_PIN, LOW);
-    gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-    gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-    gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-    gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
-  }
-  else if (OperatingParameters.hvacSetMode == FAN_ONLY)
-  {
-    if (OperatingParameters.hvacOpMode != FAN_ONLY)
-      ESP_LOGI(__FUNCTION__, "Entering fan only mode: Current: %.2f", currentTemp);
-
-    OperatingParameters.hvacOpMode = FAN_ONLY;
-    gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-    gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-    gpio_set_level((gpio_num_t)HVAC_FAN_PIN, HIGH);
-    gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-    gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-    gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-    gpio_set_level((gpio_num_t)LED_FAN_PIN, HIGH);
-  }
-  else if (OperatingParameters.hvacSetMode == HEAT)
-  {
-    if (currentTemp < minTemp)
-    {
-      if (OperatingParameters.hvacOpMode != HEAT)
-        ESP_LOGI(__FUNCTION__, "Entering heat mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
-
-      OperatingParameters.hvacOpMode = HEAT;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, HIGH);
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
-    }
-    else
-    {
+  switch (OperatingParameters.hvacSetMode) {
+  case OFF:
+    set_hvac_mode(OFF);
+    COND_LOG(prev_mode != OFF, "Entering off mode: Current: %.2f", currentTemp);
+    break;
+  case FAN_ONLY:
+    set_hvac_mode(FAN_ONLY);
+    COND_LOG(prev_mode != FAN_ONLY, "Entering fan only mode: Current: %.2f", currentTemp);
+    break;
+  case HEAT:
+    if (currentTemp < minTemp) {
+      set_hvac_mode(HEAT);
+      COND_LOG(prev_mode != HEAT, "Entering heat mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
+    } else {
       // Expected overshoot (where furnace continues to run to dissipate residual heat) is ~0.5F
       // Almost the same in Celcius.
-      if (currentTemp > maxTemp - 0.5)
-      {
-        if (OperatingParameters.hvacOpMode != IDLE)
-          ESP_LOGI(__FUNCTION__, "Stopping heat mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
-
-        OperatingParameters.hvacOpMode = IDLE;
-        gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-        gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-        gpio_set_level((gpio_num_t)HVAC_FAN_PIN, LOW);
-        gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-        gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-        gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-        gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
+      if (currentTemp > maxTemp - 0.5) {
+        set_hvac_mode(IDLE);
+        COND_LOG(prev_mode != IDLE, "Stopping heat mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
       }
     }
-  }
-  else if (OperatingParameters.hvacSetMode == AUX_HEAT)
-  {
+    break;
+  case AUX_HEAT:
     //
     // Set up for 2-stage, emergency or aux heat mode
     // Set relays correct
     //
     //@@@ still todo
     //
-    if (currentTemp < minTemp)
-    {
-      if (OperatingParameters.hvacOpMode != HEAT)
-        ESP_LOGI(__FUNCTION__, "Entering aux heat mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
-
-      OperatingParameters.hvacOpMode = HEAT;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, HIGH);
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
+    if (currentTemp < minTemp) {
+      set_hvac_mode(HEAT);
+      COND_LOG(prev_mode != HEAT, "Entering aux heat mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
+    } else {
+      set_hvac_mode(IDLE);
+      COND_LOG(prev_mode != IDLE, "Stopping aux heat mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
     }
-    else
-    {
-      if (OperatingParameters.hvacOpMode != IDLE)
-        ESP_LOGI(__FUNCTION__, "Stopping aux heat mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
-
-      OperatingParameters.hvacOpMode = IDLE;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
+    break;
+  case COOL:
+    if (currentTemp > maxTemp) {
+      set_hvac_mode(COOL);
+      COND_LOG(prev_mode != COOL, "Entering cool mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
+    } else {
+      set_hvac_mode(IDLE);
+      COND_LOG(prev_mode != IDLE, "Stopping cool mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
     }
+    break;
+  case AUTO:
+    if (currentTemp < autoMinTemp) {
+      set_hvac_mode(HEAT);
+      COND_LOG(prev_mode != HEAT, "Entering auto heat mode: Current: %.2f  auto min Limit: %.2f", currentTemp, autoMinTemp);
+    } else if (currentTemp > autoMaxTemp) {
+      set_hvac_mode(COOL);
+      COND_LOG(prev_mode != COOL, "Entering auto cool mode: Current: %.2f  auto max Limit: %.2f", currentTemp, autoMaxTemp);
+    } else {
+      set_hvac_mode(IDLE);
+      COND_LOG(prev_mode != COOL, "Exiting auto heat/cool mode: Current: %.2f  auto min Limit: %.2f  auto max Limit: %.2f", currentTemp, autoMinTemp, autoMaxTemp);
+    }
+    break;
   }
-  else if (OperatingParameters.hvacSetMode == COOL)
-  {
-    if (currentTemp > maxTemp)
-    {
-      if (OperatingParameters.hvacOpMode != COOL)
-        ESP_LOGI(__FUNCTION__, "Entering cool mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
-
-      OperatingParameters.hvacOpMode = COOL;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, HIGH);
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
-    }
-    else
-    {
-      if (OperatingParameters.hvacOpMode != IDLE)
-        ESP_LOGI(__FUNCTION__, "Stopping cool mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
-
-      OperatingParameters.hvacOpMode = IDLE;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-    }
-  }
-  else if (OperatingParameters.hvacSetMode == AUTO)
-  {
-    if (currentTemp < autoMinTemp)
-    {
-      if (OperatingParameters.hvacOpMode != HEAT)
-        ESP_LOGI(__FUNCTION__, "Entering auto heat mode: Current: %.2f  auto min Limit: %.2f", currentTemp, autoMinTemp);
-
-      OperatingParameters.hvacOpMode = HEAT;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, HIGH);
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
-    }
-    else if (currentTemp > autoMaxTemp)
-    {
-      if (OperatingParameters.hvacOpMode != COOL)
-        ESP_LOGI(__FUNCTION__, "Entering auto cool mode: Current: %.2f  auto max Limit: %.2f", currentTemp, autoMaxTemp);
-
-      OperatingParameters.hvacOpMode = COOL;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, HIGH);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, HIGH);
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
-    }
-    else
-    {
-      if (OperatingParameters.hvacOpMode != COOL)
-        ESP_LOGI(__FUNCTION__, "Exiting auto heat/cool mode: Current: %.2f  auto min Limit: %.2f  auto max Limit: %.2f", currentTemp, autoMinTemp, autoMaxTemp);
-
-      OperatingParameters.hvacOpMode = IDLE;
-      gpio_set_level((gpio_num_t)HVAC_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_FAN_PIN, LOW);
-      gpio_set_level((gpio_num_t)HVAC_STAGE2_PIN, LOW); //@@ Not used yet
-      gpio_set_level((gpio_num_t)LED_HEAT_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_COOL_PIN, LOW);
-      gpio_set_level((gpio_num_t)LED_FAN_PIN, LOW);
-    }
-  }
-
   // if ((currentTemp >= minTemp) && (currentTemp <= maxTemp) && (OperatingParameters.hvacSetMode != FAN_ONLY) && (OperatingParameters.hvacSetMode != OFF))
   // {
   //   OperatingParameters.hvacOpMode = IDLE;


### PR DESCRIPTION
Reduce duplicated code by initializing an array describing the GPIO pin states for each mode set by the state-machine.