### PR TITLE
Code update & cleanup

### DIFF
--- a/app/include/thermostat.hpp
+++ b/app/include/thermostat.hpp
@@ -63,6 +63,7 @@ typedef struct
     char FriendlyName[32];
     char DeviceName[32];
     uint8_t mac[6];
+    char ld2410FirmWare[24];
     HVAC_MODE hvacOpMode;
     HVAC_MODE hvacSetMode;
     float tempSet;
@@ -124,6 +125,8 @@ typedef struct
     bool if_init;
     /* Indicates esp_wifi_start() has been called */
     bool wifi_started;
+    /* A wifi reconnect has been requested */
+    bool reconnect_requested;
     /* Indicates active wifi connection to AP established */
     bool Connected;
     /* IP address fetched when AP connect happened */
@@ -211,6 +214,8 @@ void webStart();
 void WifiSetHostname(const char *hostname);
 void WifiSetCredentials(const char *ssid, const char *pass);
 bool WifiStart(const char *hostname, const char *ssid, const char *pass);
+bool WifiStarted();
+bool WifiRestartPending();
 bool WifiConnected();
 void WifiDisconnect();
 //bool wifiReconnect(const char *hostname, const char *ssid, const char *pass);

--- a/app/include/web_ui.h
+++ b/app/include/web_ui.h
@@ -1,6 +1,7 @@
 const char webUI[] = R"=====(
 <html>
 <meta content="width=device-width,initial-scale=1"name=viewport>
+<link rel="icon" href="data:,">
 <title>Truly Smart Thermostat</title>
 <style>body{background-color:#303030;font-family:Arial,Helvetica,Sans-Serif;Color:#cacaca}
 a{color:#006eff}h2{padding:0;margin:0}.mr{margin:10px}.pd{padding:10px}

--- a/app/src/main.cpp
+++ b/app/src/main.cpp
@@ -37,7 +37,7 @@ int64_t millis() { return esp_timer_get_time() / 1000;}
 void app_main()
 {
   // Set default log level for all components
-  esp_log_level_set("*", ESP_LOG_INFO);
+  esp_log_level_set("*", ESP_LOG_WARN);
 
   ESP_LOGI (TAG, "IDF version: %s", esp_get_idf_version());
   ESP_LOGD (TAG, "- Free memory: %d bytes", esp_get_free_heap_size());

--- a/app/src/state_machine.cpp
+++ b/app/src/state_machine.cpp
@@ -183,21 +183,13 @@ void hvacStateUpdate()
   }
 }
 
-// static inline bool wifi_reconnect_check(OPERATING_PARAMETERS *params)
-static bool wifi_reconnect_check(OPERATING_PARAMETERS *params)
+static inline bool wifi_reconnect_check(OPERATING_PARAMETERS *params)
 {
   bool ret = ( !(params->wifiConnected) && strlen(WifiCreds.ssid) && WifiStarted() ) ||
                 WifiRestartPending();
 #ifdef MATTER_ENABLED
   ret = ret && !(params->MatterStarted);
 #endif
-  if (ret == true)
-  {
-    ESP_LOGE("TEST", "wifi reconnect check:\n");
-    ESP_LOGE("TEST", "params->wifiConnected) = %d\nstrlen(WifiCreds.ssid) = %d\nWifiStarted() = %d\nWifiRestartPending() = %d\n",
-      params->wifiConnected, strlen(WifiCreds.ssid), WifiStarted(), WifiRestartPending());
-  
-  }
 return ret;
 }
 

--- a/app/src/ui/ui_events.cpp
+++ b/app/src/ui/ui_events.cpp
@@ -126,6 +126,8 @@ void StartWifiScan(lv_event_t * e)
   networkScanner();
 }
 
+extern bool wifiScanActive;
+
 void stopWifiScan(lv_event_t * e)
 {
   if (ntScanTaskHandler != NULL)
@@ -136,6 +138,7 @@ void stopWifiScan(lv_event_t * e)
   lv_label_set_text(ui_WifiStatusLabel, "Scan Aborted");
   ui_WifiStatusLabel_timestamp = millis();
   lv_obj_clear_state(ui_ScanBtn, LV_STATE_DISABLED);
+  wifiScanActive = false;
 }
 
 #define LABEL_COLOR "#850808"


### PR DESCRIPTION
Multiple fixes and improvements:
1. Default log level now set to WARN in main.cpp
2. Add support to fetch and display LD2410 FW info
3. Add support for improved wifi re-connecting (more to come in next PR)
4. Display better info regarding the heap via the telnet console
5. Detect when the time changes significantly (such as daylight savings time change in some countries). This just generates a log message.

Bug fix:
1. During a wifi scan, if the user clicks cancel the 'wifi_scan' flag was not being reset.
2. Address socket leak in telnet.cpp
3. Fix web page to not error when "favicon.ico" is requested
