### PR TITLE
Fixed socket leak when AP connection is lost

### DIFF
--- a/app/src/wifi.cpp
+++ b/app/src/wifi.cpp
@@ -341,6 +341,9 @@ static void event_handler(void* arg, esp_event_base_t event_base,
     WifiStatus.Connected = false;
     wifiConnecting = false;
     OperatingParameters.wifiConnected = false;
+    esp_wifi_disconnect();
+    esp_wifi_stop();
+
 #ifdef MATTER_ENABLED
     if (!OperatingParameters.MatterStarted)
     {


### PR DESCRIPTION
Fix for a socket leak that is encountered when the thermostat loses its connection to the WIFI access point. 