### PR TITLE
Fix ld2410

### DIFF
--- a/app/platformio.ini
+++ b/app/platformio.ini
@@ -44,7 +44,7 @@ lib_deps =
   https://github.com/smeisner/Smoothed
 	lvgl/lvgl@^8.4.0
 	lovyan03/LovyanGFX@^1.1.12
-	ncmreynolds/ld2410@^0.1.3
+	ncmreynolds/ld2410@0.1.3
 	bblanchon/ArduinoJson@^7.0.4
 debug_init_break = tbreak app_main
 monitor_filters = 


### PR DESCRIPTION

Pin ld2410 library to 0.1.3 becasue 0.1.4 is broken, and 0.1.5 is not yet released in platformio