### PR TITLE
Fixed problem where initial wifi connect fails on first attempt.

### DIFF
--- a/app/src/wifi.cpp
+++ b/app/src/wifi.cpp
@@ -333,6 +333,11 @@ static void event_handler(void* arg, esp_event_base_t event_base,
   }
   else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED)
   {
+    if (esp_wifi_connect() == ESP_OK)
+    {
+      ESP_LOGI(TAG, "Wifi reconnect worked!");
+      return;
+    }
     // The next call has a side effect of disabling logging via telnet...
 #ifdef TELNET_ENABLED
     if (telnetServiceRunning())


### PR DESCRIPTION
When initially connecting, the DISCONNECT event would always be received and there was no attempt to immediately reconnect. This change adds the attempt to reconnect.