### PR TITLE
Fix bootloop when Wi-Fi is disconnected

### DIFF
--- a/app/src/wifi.cpp
+++ b/app/src/wifi.cpp
@@ -337,7 +337,7 @@ static void event_handler(void* arg, esp_event_base_t event_base,
   {
     if (esp_wifi_connect() == ESP_OK)
     {
-      ESP_LOGI(TAG, "Wifi reconnect worked!");
+      ESP_LOGI(TAG, "Wifi reconnect initiated!");
       return;
     }
     // The next call has a side effect of disabling logging via telnet...
@@ -452,6 +452,7 @@ void WifiDeregisterEventCallbacks()
   if (s_wifi_event_group == NULL)
   {
     ESP_LOGW(TAG, "- Callbacks already deregistered");
+    return;
   }
   else
   {
@@ -703,6 +704,9 @@ void WifiDeinit()
 {
   // Set log level to 'W' (warn) as this function is quite destructive
   ESP_LOGW(TAG, "WifiDeinit()");
+
+  ESP_LOGD(TAG, "- Calling WifiDeregisterEventCallbacks()");
+  WifiDeregisterEventCallbacks();
 
   if (WifiStatus.wifi_started)
   {


### PR DESCRIPTION
When Wi-Fi configuration is incorrect (such as an unavailable SSID), the thermostat will constantly bootloop as a result of incorrect Wi-Fi teardown logic. When reconnecting (`WifiReconnect`), the teardown logic (`WifiDeinit`) does not deregister callbacks, causing mismatched state given that `esp_event_loop_delete_default` and `esp_wifi_deinit` are called. As a result, when `WifiStart` runs during reconnect, it sees already registered callbacks, but those callbacks are invalid, causing a crash and reboot when `WifiDeregisterEventCallbacks` (`WifiStart` -> `WifiRegisterEventCallbacks` -> `WifiDeregisterEventCallbacks`) attempts to teardown the callbacks.

This is my naive fix based on exploration performed by ChatGPT. It also noticed some potential issues that I've also fixed:
- `WifiDeregisterEventCallbacks` can potentially call `vEventGroupDelete` with `NULL`, so if `s_wifi_event_group` is `NULL`, then the function early-returns to avoid that
- The "Wifi reconnect worked!" log message is potentially misleading since `esp_wifi_connect` is async and only initiates the connection, so the message has been updated to say "initiated"