### PR TITLE
Added fan schedule logic to state machine.

### DIFF
--- a/app/include/thermostat.hpp
+++ b/app/include/thermostat.hpp
@@ -88,6 +88,8 @@ typedef struct
     bool thermostatBeepEnable;
     uint16_t thermostatSleepTime;
 
+    uint8_t minFanRuntime;
+
     char *timezone;
     uint16_t timezone_sel;
 

--- a/app/include/thermostat.hpp
+++ b/app/include/thermostat.hpp
@@ -88,7 +88,7 @@ typedef struct
     bool thermostatBeepEnable;
     uint16_t thermostatSleepTime;
 
-    uint64_t minFanRuntime;
+    uint64_t fanRuntimeSet;
 
     char *timezone;
     uint16_t timezone_sel;

--- a/app/include/thermostat.hpp
+++ b/app/include/thermostat.hpp
@@ -88,7 +88,7 @@ typedef struct
     bool thermostatBeepEnable;
     uint16_t thermostatSleepTime;
 
-    uint8_t minFanRuntime;
+    uint64_t minFanRuntime;
 
     char *timezone;
     uint16_t timezone_sel;

--- a/app/src/state_machine.cpp
+++ b/app/src/state_machine.cpp
@@ -230,6 +230,7 @@ void hvacStateUpdate()
   float currentTemp;
   float minTemp, maxTemp;
   float autoMinTemp, autoMaxTemp;
+  int64_t currentFanRuntime;
   HVAC_MODE prev_mode = OperatingParameters.hvacOpMode;
 
   if (ModeChangeRequested && (millis() - ModeChangeRequestTime > 2000))
@@ -252,6 +253,8 @@ void hvacStateUpdate()
   autoMinTemp = get_min_temp(&OperatingParameters, true);
   autoMaxTemp = get_max_temp(&OperatingParameters, true);
 
+  currentFanRuntime = tracker_get_sum(&tracker);
+
   switch (OperatingParameters.hvacSetMode) {
   case OFF:
     set_hvac_mode(OFF);
@@ -273,6 +276,13 @@ void hvacStateUpdate()
       {
         set_hvac_mode(IDLE);
         COND_LOG(prev_mode != IDLE, "Target temp reached: Stopping heat mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
+      } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
+        set_hvac_mode(FAN_ONLY);
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, min runtime: %.2f", 
+          currentTemp, 
+          currentFanRuntime, 
+          OperatingParameters.minFanRuntime
+        );
       }
     }
   break;
@@ -295,6 +305,13 @@ void hvacStateUpdate()
     if (currentTemp > maxTemp) {
       set_hvac_mode(COOL);
       COND_LOG(prev_mode != COOL, "Entering cool mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
+    } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
+        set_hvac_mode(FAN_ONLY);
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, min runtime: %.2f", 
+          currentTemp, 
+          currentFanRuntime, 
+          OperatingParameters.minFanRuntime
+        );
     } else {
       set_hvac_mode(IDLE);
       COND_LOG(prev_mode != IDLE, "Target temp reached: Stopping cool mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
@@ -307,6 +324,13 @@ void hvacStateUpdate()
     } else if (currentTemp > autoMaxTemp) {
       set_hvac_mode(COOL);
       COND_LOG(prev_mode != COOL, "Entering auto cool mode: Current: %.2f  auto max Limit: %.2f", currentTemp, autoMaxTemp);
+    } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
+        set_hvac_mode(FAN_ONLY);
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, min runtime: %.2f", 
+          currentTemp, 
+          currentFanRuntime, 
+          OperatingParameters.minFanRuntime
+        );
     } else {
       set_hvac_mode(IDLE);
       COND_LOG(prev_mode != IDLE, "Target temp reached: Exiting auto heat/cool mode: Current: %.2f  auto min Limit: %.2f"\

--- a/app/src/state_machine.cpp
+++ b/app/src/state_machine.cpp
@@ -196,6 +196,20 @@ static void set_hvac_mode(HVAC_MODE mode)
       ESP_LOGI(__FUNCTION__, "Hourly Fan run time: %.2f min", (tracker_get_sum(&tracker) / 1000.0 / 60.0));
     }
 
+  // Fan is continously running for circulation. Keep track and update.
+  if ((mode == FAN_ONLY) &&
+    (OperatingParameters.hvacOpMode == FAN_ONLY))
+  {
+    // Add data point with 30 second granularity to prevent overflilling buffer.
+    if (millis() - lastFanOnTime >= 30000)
+    {
+      tracker_add_value(&tracker, millis() - lastFanOnTime);
+      ESP_LOGI(__FUNCTION__, "Fan run time: %lld ms", millis() - lastFanOnTime);
+      ESP_LOGI(__FUNCTION__, "Hourly Fan run time: %.2f min", (tracker_get_sum(&tracker) / 1000.0 / 60.0));
+      lastFanOnTime = millis();
+    }
+  }
+
   OperatingParameters.hvacOpMode = mode;
 }
 
@@ -276,9 +290,9 @@ void hvacStateUpdate()
       {
         set_hvac_mode(IDLE);
         COND_LOG(prev_mode != IDLE, "Target temp reached: Stopping heat mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
-      } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
+      } else if (currentFanRuntime < OperatingParameters.minFanRuntime){
         set_hvac_mode(FAN_ONLY);
-        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, min runtime: %.2f", 
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %lld, min runtime: %lld ", 
           currentTemp, 
           currentFanRuntime, 
           OperatingParameters.minFanRuntime
@@ -307,7 +321,7 @@ void hvacStateUpdate()
       COND_LOG(prev_mode != COOL, "Entering cool mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
     } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
         set_hvac_mode(FAN_ONLY);
-        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, min runtime: %.2f", 
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %lld, min runtime: %lld", 
           currentTemp, 
           currentFanRuntime, 
           OperatingParameters.minFanRuntime
@@ -326,7 +340,7 @@ void hvacStateUpdate()
       COND_LOG(prev_mode != COOL, "Entering auto cool mode: Current: %.2f  auto max Limit: %.2f", currentTemp, autoMaxTemp);
     } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
         set_hvac_mode(FAN_ONLY);
-        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, min runtime: %.2f", 
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %lld, min runtime: %lld", 
           currentTemp, 
           currentFanRuntime, 
           OperatingParameters.minFanRuntime

--- a/app/src/state_machine.cpp
+++ b/app/src/state_machine.cpp
@@ -192,23 +192,9 @@ static void set_hvac_mode(HVAC_MODE mode)
       (OperatingParameters.hvacOpMode == FAN_ONLY || OperatingParameters.hvacOpMode == HEAT || OperatingParameters.hvacOpMode == COOL))
     {
       tracker_add_value(&tracker, millis() - lastFanOnTime);
-      ESP_LOGI(__FUNCTION__, "Fan run time: %lld ms", millis() - lastFanOnTime);
+      ESP_LOGI(__FUNCTION__, "Fan run time: %.2f min", (millis() - lastFanOnTime) / 1000.0 / 60.0);
       ESP_LOGI(__FUNCTION__, "Hourly Fan run time: %.2f min", (tracker_get_sum(&tracker) / 1000.0 / 60.0));
     }
-
-  // Fan is continously running for circulation. Keep track and update.
-  if ((mode == FAN_ONLY) &&
-    (OperatingParameters.hvacOpMode == FAN_ONLY))
-  {
-    // Add data point with 30 second granularity to prevent overflilling buffer.
-    if (millis() - lastFanOnTime >= 30000)
-    {
-      tracker_add_value(&tracker, millis() - lastFanOnTime);
-      ESP_LOGI(__FUNCTION__, "Fan run time: %lld ms", millis() - lastFanOnTime);
-      ESP_LOGI(__FUNCTION__, "Hourly Fan run time: %.2f min", (tracker_get_sum(&tracker) / 1000.0 / 60.0));
-      lastFanOnTime = millis();
-    }
-  }
 
   OperatingParameters.hvacOpMode = mode;
 }
@@ -269,6 +255,9 @@ void hvacStateUpdate()
 
   currentFanRuntime = tracker_get_sum(&tracker);
 
+  if (prev_mode != IDLE && prev_mode != OFF) 
+    currentFanRuntime += millis() - lastFanOnTime;
+
   switch (OperatingParameters.hvacSetMode) {
   case OFF:
     set_hvac_mode(OFF);
@@ -290,12 +279,12 @@ void hvacStateUpdate()
       {
         set_hvac_mode(IDLE);
         COND_LOG(prev_mode != IDLE, "Target temp reached: Stopping heat mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
-      } else if (currentFanRuntime < OperatingParameters.minFanRuntime){
+      } else if (currentFanRuntime < OperatingParameters.fanRuntimeSet) {
         set_hvac_mode(FAN_ONLY);
-        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %lld, min runtime: %lld ", 
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, set runtime: %.2f ", 
           currentTemp, 
-          currentFanRuntime, 
-          OperatingParameters.minFanRuntime
+          currentFanRuntime / 1000.0 / 60.0, 
+          OperatingParameters.fanRuntimeSet / 1000.0 / 60.0
         );
       }
     }
@@ -319,13 +308,13 @@ void hvacStateUpdate()
     if (currentTemp > maxTemp) {
       set_hvac_mode(COOL);
       COND_LOG(prev_mode != COOL, "Entering cool mode: Current: %.2f  Hi Limit: %.2f", currentTemp, maxTemp);
-    } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
-        set_hvac_mode(FAN_ONLY);
-        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %lld, min runtime: %lld", 
-          currentTemp, 
-          currentFanRuntime, 
-          OperatingParameters.minFanRuntime
-        );
+    } else if (currentFanRuntime < OperatingParameters.fanRuntimeSet) {
+      set_hvac_mode(FAN_ONLY);
+      COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, set runtime: %.2f ", 
+        currentTemp, 
+        currentFanRuntime / 1000.0 / 60.0, 
+        OperatingParameters.fanRuntimeSet / 1000.0 / 60.0
+      );
     } else {
       set_hvac_mode(IDLE);
       COND_LOG(prev_mode != IDLE, "Target temp reached: Stopping cool mode: Current: %.2f  Lo Limit: %.2f", currentTemp, minTemp);
@@ -338,12 +327,12 @@ void hvacStateUpdate()
     } else if (currentTemp > autoMaxTemp) {
       set_hvac_mode(COOL);
       COND_LOG(prev_mode != COOL, "Entering auto cool mode: Current: %.2f  auto max Limit: %.2f", currentTemp, autoMaxTemp);
-    } else if (currentFanRuntime < OperatingParameters.minFanRuntime ){
+    } else if (currentFanRuntime < OperatingParameters.fanRuntimeSet) {
         set_hvac_mode(FAN_ONLY);
-        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %lld, min runtime: %lld", 
+        COND_LOG(prev_mode != FAN_ONLY, "Running fan: Current: %.2f, fan runtime: %.2f, set runtime: %.2f ", 
           currentTemp, 
-          currentFanRuntime, 
-          OperatingParameters.minFanRuntime
+          currentFanRuntime / 1000.0 / 60.0, 
+          OperatingParameters.fanRuntimeSet / 1000.0 / 60.0
         );
     } else {
       set_hvac_mode(IDLE);


### PR DESCRIPTION
Related to https://github.com/smeisner/smart-thermostat/issues/68

- Update hvacStateUpdate to run fan for circulation
- Updated set_hvac_mode to track fan runtime from FAN_ONLY to FAN_ONLY

Testing by setting tempSet to a higher value than the environment and minimum fan runtime to be 5 mins. I observed the state machine enter IDLE mode after 5 minutes of being in FAN_ONLY mode. I set these parameters in main:
```C++
  OperatingParameters.minFanRuntime = 300000;
  OperatingParameters.hvacSetMode = COOL;
  OperatingParameters.tempSet = 78.0;
  ESP_LOGI (TAG, "Values set in main: minFanRuntime: %lld hvacSetMode: %d tempSet: %.2f", 
    OperatingParameters.minFanRuntime,
    OperatingParameters.hvacSetMode,
    OperatingParameters.tempSet
  );
```